### PR TITLE
Remove Symfony deprecation contracts from required packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
         "symfony/form": "^4.4||^5.3||^6.0",
         "symfony/framework-bundle": "^4.4||^5.3||^6.0",
         "symfony/http-kernel": "^4.4||^5.3||^6.0",
-        "symfony/deprecation-contracts": "^2.1",
         "symfony/options-resolver": "^4.4||^5.3||^6.0",
         "symfony/property-access": "^4.4||^5.3||^6.0"
     },


### PR DESCRIPTION
`symfony/deprecation-contracts`  is not needed any more, because the legacy code that triggered deprecations has been removed. 

Additionally, it caused problems when trying to install `qossmic/rich-model-forms-bundle` on projects that require `symfony/deprecation-contracts` in version 3.